### PR TITLE
Update to clean up behavior

### DIFF
--- a/UPMFix/UPMFix.lua
+++ b/UPMFix/UPMFix.lua
@@ -26,11 +26,10 @@ function UnitPopupManager:OnUpdate(elapsed)
 					if(shown) then
 						count = count + 1;
 						local enable = UnitPopupSharedUtil:IsEnabled(button);
+						local text = button:GetText(); 
 						local diff = (level > 1) and 0 or 1;
 						tempCount = count + diff; 
-						if(button.isSubsectionTitle) then 
-							count = count + 1; 
-						elseif (not button.isSubsection) then
+						if(text == not '') then 
 							if (enable) then
 								UIDropDownMenu_EnableButton(level, tempCount);
 							else 


### PR DESCRIPTION
Only Enable/Disable a button if it has Text.
The problem stems from them having two types of separators, Seperators and SeparatorTitles.